### PR TITLE
Fix: Add missing passed_args to mesh_segmentation method

### DIFF
--- a/tripo3d/client.py
+++ b/tripo3d/client.py
@@ -1010,7 +1010,7 @@ class TripoClient:
         }
 
         # Add optional parameters that were explicitly passed
-        self._add_optional_params(task_data)
+        self._add_optional_params(task_data, passed_args=self._get_passed_args())
 
         return await self.create_task(task_data)
 


### PR DESCRIPTION
### Summary

Fixes #7

Added the missing `passed_args` argument to the `_add_optional_params()` call in the `mesh_segmentation` method.

### Problem

The `mesh_segmentation` method was calling `_add_optional_params(task_data)` without the required `passed_args` argument, causing a `TypeError` when invoked:
```
TypeError: TripoClient._add_optional_params() missing 1 required positional argument: 'passed_args'
```

### Solution

Updated the method to be consistent with other methods (e.g., `smart_lowpoly`, `mesh_completion`):
```python
# Before
self._add_optional_params(task_data)

# After
self._add_optional_params(
    task_data,
    passed_args=self._get_passed_args(),
)
```

### Testing

Verified that `mesh_segmentation` now works correctly:
```python
async with TripoClient() as client:
    task_id = await client.image_to_model(image="test.jpg")
    await client.wait_for_task(task_id)
    
    # Works without the TypeError now
    seg_task_id = await client.mesh_segmentation(
        original_model_task_id=task_id
    )
```