### PR TITLE
fix: TaskOutput.image reads generated_image from API response

### DIFF
--- a/tripo3d/models.py
+++ b/tripo3d/models.py
@@ -87,7 +87,7 @@ class TaskOutput:
             rendered_image=data.get('rendered_image'),
             riggable=data.get('riggable'),
             rig_type=data.get('rig_type'),
-            image=data.get('image'),
+            image=data.get('generated_image') or data.get('image'),
             front_view_url=multiview.get('front_view_url'),
             left_view_url=multiview.get('left_view_url'),
             back_view_url=multiview.get('back_view_url'),


### PR DESCRIPTION
## Summary

- `TaskOutput.from_dict` now reads `generated_image` field (with `image` as fallback) from API response
- Without this fix, `download_task_models` returns empty results for `text_to_image` and `generate_image` tasks

## Root cause

Backend returns output as `{"generated_image": "https://..."}`, but SDK was reading `data.get('image')` which is always `None`.

## Test plan

- [x] E2E verified: `text_to_image` output downloaded 86KB jpeg via `download_task_models`
- [x] `generate_image` output also contains `generated_image` field (confirmed via raw API response)
- [x] Backward compatible: falls back to `data.get('image')` if `generated_image` is absent

Made with [Cursor](https://cursor.com)